### PR TITLE
fix: clone headers in all constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Built on [Undici](https://github.com/nodejs/undici)
 			- [`Headers.has(name)`](#headershasname)
 			- [`Headers.set(name, value)`](#headerssetname-value)
 			- [`Headers.values()`](#headersvalues)
-			- [`Headers.entries()`](#headersentries)
 			- [`Headers.keys()`](#headerskeys)
+			- [`Headers.forEach(callback, [thisArg])`](#headersforeachcallback-thisarg)
 			- [`Headers[Symbol.iterator]`](#headerssymboliterator)
+			- [`Headers.entries()`](#headersentries)
 	- [Class: Body](#class-body)
 		- [`new Body([input])`](#new-bodyinput)
 		- [Instance Properties](#instance-properties)
@@ -161,11 +162,11 @@ Represents a WHATWG Fetch Spec [Headers Class](https://fetch.spec.whatwg.org/#he
 ```js
 new Headers()
 
-const headers = new Headers([
+new Headers([
 	["undici", "fetch"]
 ])
 
-new Headers({
+const headers = new Headers({
 	"undici": "fetch"
 })
 
@@ -313,6 +314,24 @@ for (const name of headers.keys()) {
 // -> 'abc'
 // -> 'def'
 // -> 'ghi'
+```
+#### `Headers.forEach(callback, [thisArg])`
+
+Returns: `void`
+
+A Headers class can be iterated using `.forEach(callback, [thisArg])` where the callback has the following signature
+
+`(value: string, key: string, iterable: Headers) => void`
+
+Optionally a `thisArg` can be passed which will be assigned to the this context of the callback
+
+```js
+const headers = new Headers([['abc', '123']])
+
+headers.forEach(function (value, key, headers) {
+	console.log(key, value)
+})
+// -> 'abc', '123'
 ```
 
 #### `Headers[Symbol.iterator]`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Built on [Undici](https://github.com/nodejs/undici)
 			- [`Headers.get(name)`](#headersgetname)
 			- [`Headers.has(name)`](#headershasname)
 			- [`Headers.set(name, value)`](#headerssetname-value)
+			- [`Headers.values()`](#headersvalues)
+			- [`Headers.entries()`](#headersentries)
+			- [`Headers.keys()`](#headerskeys)
 			- [`Headers[Symbol.iterator]`](#headerssymboliterator)
 	- [Class: Body](#class-body)
 		- [`new Body([input])`](#new-bodyinput)
@@ -153,18 +156,20 @@ Represents a WHATWG Fetch Spec [Headers Class](https://fetch.spec.whatwg.org/#he
 
 ### `new Headers([init])`
 
-* **init** `[string, string][] | Record<string, string>` (optional) - Initial header list to be cloned into the new instance
+* **init** `Iterable<[string, string]> | Record<string, string>` (optional) - Initial header list to be cloned into the new instance
 
 ```js
 new Headers()
 
-new Headers([
+const headers = new Headers([
 	["undici", "fetch"]
 ])
 
 new Headers({
 	"undici": "fetch"
 })
+
+new Headers(headers)
 ```
 
 ### Instance Methods
@@ -264,11 +269,11 @@ headers.set('foobar', 'buzz')
 headers.get('foobar') // -> 'buzz'
 ```
 
-#### `Headers[Symbol.iterator]`
+#### `Headers.values()`
 
-Returns: `[string, string[]]`
+Returns: `IteratableIterator<string>`
 
-A Headers class instance is iterable. It yields each of its entries as a pair where the first value is the entry _name_ and the second value is an array of the entry _values_.
+Each iteration of the headers `values()` iterator yields a header _value_
 
 ```js
 const headers = new Headers()
@@ -276,15 +281,67 @@ const headers = new Headers()
 headers.set('abc', '123')
 headers.set('def', '456')
 headers.set('ghi', '789')
+headers.append('ghi', '012')
+
+for (const value of headers.values()) {
+	console.log(value)
+}
+
+// -> '123'
+// -> '456'
+// -> '789, 012'
+```
+
+#### `Headers.keys()`
+
+Returns: `IteratableIterator<string>`
+
+Each iteration of the headers `keys()` iterator yields a header _name_
+
+```js
+const headers = new Headers()
+
+headers.set('abc', '123')
+headers.set('def', '456')
+headers.set('ghi', '789')
+headers.append('ghi', '012')
+
+for (const name of headers.keys()) {
+	console.log(name)
+}
+
+// -> 'abc'
+// -> 'def'
+// -> 'ghi'
+```
+
+#### `Headers[Symbol.iterator]`
+
+Returns: `Iterator<[string, string]>`
+
+A Headers class instance is iterable. It yields each of its entries as a pair where the first value is the entry _name_ and the second value is the header _value_.
+
+```js
+const headers = new Headers()
+
+headers.set('abc', '123')
+headers.set('def', '456')
+headers.set('ghi', '789')
+headers.append('ghi', '012')
 
 for (const [name, value] of headers) {
 	console.log(name, value)
 }
 
-// -> 'abc', [ '123' ]
-// -> 'def', [ '456' ]
-// -> 'ghi', [ '789' ]
+// -> 'abc', '123'
+// -> 'def', '456'
+// -> 'ghi', '789, 012'
 ```
+#### `Headers.entries()`
+
+Returns: `IteratableIterator<[string, string]>`
+
+Each iteration of the headers `entries()` iterator yields the same entry result as the default iterator
 
 ## Class: Body
 

--- a/README.md
+++ b/README.md
@@ -317,13 +317,14 @@ for (const name of headers.keys()) {
 ```
 #### `Headers.forEach(callback, [thisArg])`
 
+* **callback** `(value: string, key: string, iterable: Headers) => void`
+* **thisArg** `any` (optional)
+
 Returns: `void`
 
-A Headers class can be iterated using `.forEach(callback, [thisArg])` where the callback has the following signature
+A Headers class can be iterated using `.forEach(callback, [thisArg])`
 
-`(value: string, key: string, iterable: Headers) => void`
-
-Optionally a `thisArg` can be passed which will be assigned to the this context of the callback
+Optionally a `thisArg` can be passed which will be assigned to the `this` context of callback
 
 ```js
 const headers = new Headers([['abc', '123']])

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ declare class Headers {
 	get(name: string): string | null;
 	has(name: string): boolean;
 	set(name: string, value: string): void;
-	[Symbol.iterator](): [string, string[]];
+	[Symbol.iterator](): Iterator<[string, string]>;
 }
 
 type RequestInit = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,10 @@ declare class Headers implements Iterable<[string,string]> {
 	has(name: string): boolean;
 	set(name: string, value: string): void;
 	entries(): IterableIterator<[string, string]>;
+	forEach(
+		callbackfn: (value: string, key: string, iterable: Headers) => void,
+		thisArg?: any
+	): void;
 	keys(): IterableIterator<string>;
 	values(): IterableIterator<string>;
 	[Symbol.iterator](): Iterator<[string, string]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,14 +26,16 @@ declare class Body {
 
 type HeadersInit = [string, string][] | Record<string, string>;
 
-declare class Headers {
+declare class Headers implements Iterable<[string,string]> {
 	constructor (init?: HeadersInit);
-
 	append(name: string, value: string): void;
 	delete(name: string): void;
 	get(name: string): string | null;
 	has(name: string): boolean;
 	set(name: string, value: string): void;
+	entries(): IterableIterator<[string, string]>;
+	keys(): IterableIterator<string>;
+	values(): IterableIterator<string>;
 	[Symbol.iterator](): Iterator<[string, string]>;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare class Body {
 	text(): Promise<string>;
 }
 
-type HeadersInit = [string, string][] | Record<string, string>;
+type HeadersInit = Iterable<[string, string]> | Record<string, string>;
 
 declare class Headers implements Iterable<[string,string]> {
 	constructor (init?: HeadersInit);

--- a/src/headers.js
+++ b/src/headers.js
@@ -71,6 +71,12 @@ class Headers {
     return this[kHeaders].entries()
   }
 
+  forEach (callback, thisArg) {
+    for (const [key, value] of this) {
+      callback.call(thisArg, value, key, this)
+    }
+  }
+
   [Symbol.iterator] () {
     return this[kHeaders][Symbol.iterator]()
   }

--- a/src/headers.js
+++ b/src/headers.js
@@ -17,9 +17,7 @@ class Headers {
           this.append(header[0], header[1])
         }
       } else if (kHeaders in init) {
-        for (const [name, values] of init[kHeaders]) {
-          this[kHeaders].set(name, values.slice())
-        }
+        this[kHeaders] = new Map(init[kHeaders])
       } else if (!types.isBoxedPrimitive(init)) {
         for (const [name, value] of Object.entries(init)) {
           this.append(name, value)
@@ -31,40 +29,50 @@ class Headers {
   append (name, value) {
     const [normalizedHeaderName, normalizedHeaderValue] = normalizeAndValidateHeaderArguments(name, value)
 
-    const existingHeaderValue = (Map.prototype.get.call(this[kHeaders], normalizedHeaderName) || []).slice()
-    existingHeaderValue.push(normalizedHeaderValue)
-    Map.prototype.set.call(this[kHeaders], normalizedHeaderName, existingHeaderValue)
+    const existing = this[kHeaders].get(normalizedHeaderName)
+    const newHeaderValue = existing ? existing + ', ' + normalizedHeaderValue : normalizedHeaderValue
+    this[kHeaders].set(normalizedHeaderName, newHeaderValue)
   }
 
   delete (name) {
     const normalizedHeaderName = normalizeAndValidateHeaderName(name)
 
-    Map.prototype.delete.call(this[kHeaders], normalizedHeaderName)
+    this[kHeaders].delete(normalizedHeaderName)
   }
 
   get (name) {
     const normalizedHeaderName = normalizeAndValidateHeaderName(name)
 
-    const values = Map.prototype.get.call(this[kHeaders], normalizedHeaderName)
-    return values === undefined ? null : values.join(', ')
+    const value = this[kHeaders].get(normalizedHeaderName)
+    return value === undefined ? null : value
   }
 
   has (name) {
     const normalizedHeaderName = normalizeAndValidateHeaderName(name)
 
-    return Map.prototype.has.call(this[kHeaders], normalizedHeaderName)
+    return this[kHeaders].has(normalizedHeaderName)
   }
 
   set (name, value) {
     const [normalizedHeaderName, normalizedHeaderValue] = normalizeAndValidateHeaderArguments(name, value)
 
-    Map.prototype.set.call(this[kHeaders], normalizedHeaderName, [normalizedHeaderValue])
+    this[kHeaders].set(normalizedHeaderName, normalizedHeaderValue)
   }
 
-  * [Symbol.iterator] () {
-    for (const [name, values] of this[kHeaders]) {
-      yield [name, values.join(', ')]
-    }
+  keys () {
+    return this[kHeaders].keys()
+  }
+
+  values () {
+    return this[kHeaders].values()
+  }
+
+  entries () {
+    return this[kHeaders].entries()
+  }
+
+  [Symbol.iterator] () {
+    return this[kHeaders][Symbol.iterator]()
   }
 }
 

--- a/src/request.js
+++ b/src/request.js
@@ -37,7 +37,7 @@ class Request extends Body {
     if (input instanceof Request) {
       return new Request(input.url, {
         method: input.method,
-        headers: input.headers,
+        headers: new Headers(input.headers),
         body: input.body,
         ...init
       })

--- a/src/response.js
+++ b/src/response.js
@@ -21,7 +21,7 @@ class Response extends Body {
       throw TypeError(`Response statusText must be of type string. Found type: ${typeof init.statusText}`)
     }
 
-    this.headers = init.headers instanceof Headers ? init.headers : new Headers(init.headers)
+    this.headers = new Headers(init.headers)
     this.ok = init.status >= 200 && init.status <= 299
     this.status = init.status
     this.statusText = init.statusText

--- a/test/headers.js
+++ b/test/headers.js
@@ -214,7 +214,23 @@ tap.test('Headers set', t => {
 })
 
 tap.test('Headers as Iterable', t => {
-  t.plan(4)
+  t.plan(5)
+
+  t.test('forEach', t => {
+    t.plan(9)
+    const init = {
+      abc: '123',
+      def: '456',
+      ghi: '789'
+    }
+    const that = {}
+    const headers = new Headers(init)
+    headers.forEach(function (v, k, h) {
+      t.strictEqual(init[k], v)
+      t.equal(headers, h)
+      t.equal(this, that)
+    }, that)
+  })
 
   t.test('entries', t => {
     t.plan(1)

--- a/test/headers.js
+++ b/test/headers.js
@@ -213,15 +213,49 @@ tap.test('Headers set', t => {
   })
 })
 
-tap.test('Headers [Symbol.iterator]', t => {
-  t.plan(3)
-  const init = {
-    abc: '123',
-    def: '456',
-    ghi: '789'
-  }
-  const headers = new Headers(init)
-  for (const [name, value] of headers) {
-    t.strictDeepEqual(value, init[name])
-  }
+tap.test('Headers as Iterable', t => {
+  t.plan(4)
+
+  t.test('entries', t => {
+    t.plan(1)
+    const init = {
+      abc: '123',
+      def: '456',
+      ghi: '789'
+    }
+    t.strictDeepEqual(Object.entries(init), [...new Headers(init).entries()])
+  })
+
+  t.test('keys', t => {
+    t.plan(1)
+    const init = {
+      abc: '123',
+      def: '456',
+      ghi: '789'
+    }
+    t.strictDeepEqual(Object.keys(init), [...new Headers(init).keys()])
+  })
+
+  t.test('values', t => {
+    t.plan(1)
+    const init = {
+      abc: '123',
+      def: '456',
+      ghi: '789'
+    }
+    t.strictDeepEqual(Object.values(init), [...new Headers(init).values()])
+  })
+
+  t.test('iterator', t => {
+    t.plan(3)
+    const init = {
+      abc: '123',
+      def: '456',
+      ghi: '789'
+    }
+    const headers = new Headers(init)
+    for (const [name, value] of headers) {
+      t.strictDeepEqual(value, init[name])
+    }
+  })
 })

--- a/test/headers.js
+++ b/test/headers.js
@@ -4,7 +4,7 @@ const tap = require('tap')
 const Headers = require('../src/headers')
 
 tap.test('Headers initialization', t => {
-  t.plan(4)
+  t.plan(6)
 
   t.test('allows undefined', t => {
     t.plan(1)
@@ -37,13 +37,31 @@ tap.test('Headers initialization', t => {
     t.notThrow(() => new Headers(init))
   })
 
-  t.test('fails silently if primitive object is passed', t => {
-    t.plan(5)
-    t.notThrow(() => new Headers(Number))
-    t.notThrow(() => new Headers(Boolean))
-    t.notThrow(() => new Headers(String))
-    t.notThrow(() => new Headers(Array))
+  t.test('with existing headers object', t => {
+    t.plan(1)
+    const init = new Headers({
+      undici: 'fetch',
+      fetch: 'undici'
+    })
+    const clone = new Headers(init)
+    t.strictDeepEqual(init, clone)
+  })
+
+  t.test('fails silently if a boxed primitive object is passed', t => {
+    t.plan(3)
+    /* eslint-disable no-new-wrappers */
+    t.notThrow(() => new Headers(new Number()))
+    t.notThrow(() => new Headers(new Boolean()))
+    t.notThrow(() => new Headers(new String()))
+    /* eslint-enable no-new-wrappers */
+  })
+
+  t.test('fails silently if function or primitive is passed', t => {
+    t.plan(4)
     t.notThrow(() => new Headers(Function))
+    t.notThrow(() => new Headers(function () {}))
+    t.notThrow(() => new Headers(1))
+    t.notThrow(() => new Headers('1'))
   })
 })
 
@@ -204,6 +222,6 @@ tap.test('Headers [Symbol.iterator]', t => {
   }
   const headers = new Headers(init)
   for (const [name, value] of headers) {
-    t.strictDeepEqual(value, [init[name]])
+    t.strictDeepEqual(value, init[name])
   }
 })

--- a/test/request.js
+++ b/test/request.js
@@ -39,13 +39,13 @@ tap.test('Request initialization', t => {
   })
 
   t.test('new request inherits from request input', t => {
-    t.plan(5)
+    t.plan(6)
 
     const request1 = new Request(validURL, { headers: [['undici', 'fetch']] })
 
     const request2 = new Request(request1)
     t.strictDeepEqual(request1, request2)
-
+    t.notEqual(request1.headers, request2.headers)
     const request3 = new Request(request1, { method: 'POST' })
     t.strictDeepEqual(request1.url, request3.url)
     t.strictDeepEqual(request1.headers, request3.headers)

--- a/test/response.js
+++ b/test/response.js
@@ -26,9 +26,10 @@ tap.test('Response.clone', t => {
   t.plan(2)
 
   t.test('returns new response instance when bodyUsed is false', t => {
-    t.plan(1)
+    t.plan(2)
     const response1 = new Response(new Readable(), { headers: [['undici', 'fetch']] })
     const response2 = response1.clone()
+    t.notEqual(response1.headers, response2.headers)
     t.strictDeepEqual(response1, response2)
   })
 


### PR DESCRIPTION
Excited to use this - This PR should close #5 !

Since header objects are iterable records they should be able to clone themselves
 
- I added a symbol check to short circuit init/validation and deeply copy the internal map
- fixed up the iterator type and implementation
- fixed some tests for boxed primitives and added a few for the else branches and reference equality checks.

The Request/Response constructors can now just use `new Headers`

