### PR TITLE
Fix for Headers iterator type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ declare class Headers {
 	get(name: string): string | null;
 	has(name: string): boolean;
 	set(name: string, value: string): void;
-	[Symbol.iterator](): [string, string[]];
+	[Symbol.iterator](): Generator<[string, string[]]>;
 }
 
 type RequestInit = {


### PR DESCRIPTION
The current `Headers` type throws a TypeScript compile error when using a for-of loop:

```ts
import fetch from "./index.js";

async function main() {
  const resp = await fetch("/foo");
  for (const [key, values] of resp.headers) {
    console.log(key, values);
  }
}

```

This change fixes the issue for me.