### PR TITLE
Pass headers as entries

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -5,6 +5,17 @@ const Request = require('./request')
 const Response = require('./response')
 const { STATUS_CODES } = require('http')
 
+function toUndiciHeaders (headers) {
+  if (headers == null) {
+    return undefined
+  }
+  const result = []
+  headers.forEach((value, name) => {
+    result.push(name, value)
+  })
+  return result
+}
+
 function buildFetch (undiciPoolOpts) {
   if (arguments.length > 0) {
     throw Error('Did you forget to build the instance? Try: `const fetch = require(\'fetch\')()`')
@@ -27,7 +38,7 @@ function buildFetch (undiciPoolOpts) {
         path: request.url.pathname,
         method: request.method,
         body: request.body,
-        headers: request.headers,
+        headers: toUndiciHeaders(request.headers),
         signal: init.signal
       }, (err, data) => {
         if (err) return reject(err)


### PR DESCRIPTION
`Request#headers` is an instance of `Headers` but undici [expects](https://github.com/nodejs/undici/blob/2366fa34e30ac5a8c33a3d02259f2ae0f7678c85/docs/api/Client.md#parameter-undiciheaders) either an object or an array.