### PR TITLE
Fix query string handling; clean up tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@
 
 ### `t.teardown()` step
 
-Many tests for this module require an http server. It is recommend to use a teardown method to safely close the server(s) and fetch clients. Additionally, due to the way http servers are closed in Node.js, you should close the fetch clients first then the http server(s). Furthermore, the `server.close` method is not promised based so in order to use it with `await`, use the `promisifyServerClose` utility method.
+Many tests for this module require an http server. It is recommend to use a teardown method to safely close the server(s) and fetch clients. Additionally, due to the way http servers are closed in Node.js, you should close the fetch clients first then the http server(s). Furthermore, the `server.close` method is not promised based so in order to use it with `await`, use the `closeServer` utility method.
 
 For example:
 
 ```js
 t.teardown(async () => {
 	await fetch.close()
-	await promisifyServerClose(server)
+	await closeServer(server)
 })
 ```

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,11 +3,15 @@
 const Undici = require('undici')
 const Request = require('./request')
 const Response = require('./response')
+const { createUndiciRequestOptions } = require('./utils')
 const { STATUS_CODES } = require('http')
+const { promisify } = require('util')
+
+const requestAsync = promisify(Undici.Pool.prototype.request)
 
 function buildFetch (undiciPoolOpts) {
   if (arguments.length > 0) {
-    throw Error('Did you forget to build the instance? Try: `const fetch = require(\'fetch\')()`')
+    throw Error('Did you forget to build the instance? Try: `const fetch = require(\'undici-fetch\')()`')
   }
 
   const clientMap = new Map()
@@ -15,41 +19,30 @@ function buildFetch (undiciPoolOpts) {
   function fetch (resource, init = {}) {
     const request = new Request(resource, init)
 
-    const origin = request.url.origin
-    let client = clientMap.get(origin)
-    if (client === undefined) {
+    const { origin } = request.url
+    let client
+    if (clientMap.has(origin)) {
+      client = clientMap.get(origin)
+    } else {
       client = new Undici.Pool(origin, undiciPoolOpts)
       clientMap.set(origin, client)
     }
 
-    return new Promise((resolve, reject) => {
-      client.request({
-        path: request.url.pathname,
-        method: request.method,
-        body: request.body,
-        headers: request.headers,
-        signal: init.signal
-      }, (err, data) => {
-        if (err) return reject(err)
+    const requestOptions = createUndiciRequestOptions(request, init.signal)
 
-        resolve(new Response(data.body, {
-          status: data.statusCode,
-          statusText: STATUS_CODES[data.statusCode],
-          headers: data.headers
-        }))
-      })
-    })
+    return requestAsync.call(client, requestOptions)
+      .then(data => new Response(data.body, {
+        status: data.statusCode,
+        statusText: STATUS_CODES[data.statusCode],
+        headers: data.headers
+      }))
   }
 
-  fetch.close = () => {
-    const clientClosePromises = []
-    for (const [, client] of clientMap) {
-      if (!client.closed) {
-        clientClosePromises.push(client.close())
-      }
-    }
-    return Promise.all(clientClosePromises)
-  }
+  fetch.close = () => Promise.all(
+    Array.from(clientMap.values())
+      .filter(client => !client.closed)
+      .map(client => client.close())
+  )
 
   return fetch
 }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -44,7 +44,9 @@ function buildFetch (undiciPoolOpts) {
   fetch.close = () => {
     const clientClosePromises = []
     for (const [, client] of clientMap) {
-      clientClosePromises.push(client.close.bind(client)())
+      if (!client.closed) {
+        clientClosePromises.push(client.close())
+      }
     }
     return Promise.all(clientClosePromises)
   }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -5,9 +5,6 @@ const Request = require('./request')
 const Response = require('./response')
 const { createUndiciRequestOptions } = require('./utils')
 const { STATUS_CODES } = require('http')
-const { promisify } = require('util')
-
-const requestAsync = promisify(Undici.Pool.prototype.request)
 
 function buildFetch (undiciPoolOpts) {
   if (arguments.length > 0) {
@@ -30,7 +27,7 @@ function buildFetch (undiciPoolOpts) {
 
     const requestOptions = createUndiciRequestOptions(request, init.signal)
 
-    return requestAsync.call(client, requestOptions)
+    return client.request(requestOptions)
       .then(data => new Response(data.body, {
         status: data.statusCode,
         statusText: STATUS_CODES[data.statusCode],

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -17,10 +17,8 @@ function buildFetch (undiciPoolOpts) {
     const request = new Request(resource, init)
 
     const { origin } = request.url
-    let client
-    if (clientMap.has(origin)) {
-      client = clientMap.get(origin)
-    } else {
+    let client = clientMap.get(origin)
+    if (client === undefined) {
       client = new Undici.Pool(origin, undiciPoolOpts)
       clientMap.set(origin, client)
     }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -31,6 +31,10 @@ function buildFetch (undiciPoolOpts) {
         statusText: STATUS_CODES[data.statusCode],
         headers: data.headers
       }))
+      .catch(err => {
+        // TODO Convert Undici error to Fetch API error
+        throw err
+      })
   }
 
   fetch.close = () => Promise.all(

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,17 +70,11 @@ function normalizeAndValidateHeaderArguments (name, value) {
 }
 
 function createUndiciRequestOptions (request, signal) {
-  const {
-    url: { pathname, search },
-    method,
-    headers,
-    body
-  } = request
   return {
-    path: pathname + search,
-    method,
-    body,
-    headers,
+    path: request.url.pathname + request.url.search,
+    method: request.method,
+    body: request.body,
+    headers: request.headers,
     signal
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,6 +69,22 @@ function normalizeAndValidateHeaderArguments (name, value) {
   return [normalizeAndValidateHeaderName(name), normalizeAndValidateHeaderValue(name, value)]
 }
 
+function createUndiciRequestOptions (request, signal) {
+  const {
+    url: { pathname, search },
+    method,
+    headers,
+    body
+  } = request
+  return {
+    path: pathname + search,
+    method,
+    body,
+    headers,
+    signal
+  }
+}
+
 module.exports = {
   isReadable,
   HeaderNameValidationError,
@@ -77,5 +93,6 @@ module.exports = {
   validateHeaderValue,
   normalizeAndValidateHeaderName,
   normalizeAndValidateHeaderValue,
-  normalizeAndValidateHeaderArguments
+  normalizeAndValidateHeaderArguments,
+  createUndiciRequestOptions
 }

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -58,7 +58,7 @@ tap.test('fetch can handle basic requests', t => {
     t.plan(2)
 
     const wanted = 'undici-fetch'
-    
+
     const server = http.createServer((req, res) => {
       t.strictEqual(req.method, 'POST')
       req.setEncoding('utf8')

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -5,7 +5,7 @@ const semver = require('semver')
 const http = require('http')
 const { Readable } = require('stream')
 const { errors } = require('undici')
-const { promisifyServerClose } = require('./testUtils')
+const { closeServer } = require('./testUtils')
 
 const validURL = 'https://undici-fetch.dev'
 
@@ -33,6 +33,7 @@ tap.test('fetch can handle basic requests', t => {
     t.plan(2)
 
     const wanted = 'undici-fetch'
+
     const server = http.createServer((req, res) => {
       t.strictEqual(req.method, 'GET')
       res.write(wanted)
@@ -41,45 +42,52 @@ tap.test('fetch can handle basic requests', t => {
 
     t.tearDown(async () => {
       await fetch.close()
-      await promisifyServerClose(server)()
+      await closeServer(server)
     })
 
     server.listen(0, async () => {
-      const res = await fetch(`http://localhost:${server.address().port}`)
+      const { port } = server.address()
+      const res = await fetch(`http://localhost:${port}/`)
       const found = await res.text()
 
-      t.strictEquals(found, wanted)
+      t.strictEqual(found, wanted)
     })
   })
 
   t.test('simple POST request', t => {
     t.plan(2)
-    const wanted = 'undici-fetch'
 
+    const wanted = 'undici-fetch'
+    
     const server = http.createServer((req, res) => {
       t.strictEqual(req.method, 'POST')
       req.setEncoding('utf8')
       let found = ''
-      req.on('data', d => { found += d })
+      req.on('data', d => {
+        found += d
+      })
       req.on('end', () => {
-        t.strictEqual(found, wanted)
+        res.write(found)
         res.end()
       })
     })
 
     t.tearDown(async () => {
       await fetch.close()
-      await promisifyServerClose(server)()
+      await closeServer(server)
     })
 
-    server.listen(0, () => {
-      fetch(
-        `http://localhost:${server.address().port}`,
+    server.listen(0, async () => {
+      const { port } = server.address()
+      const res = await fetch(
+        `http://localhost:${port}/`,
         {
           method: 'POST',
           body: Readable.from(wanted, { objectMode: false })
         }
       )
+      const found = await res.text()
+      t.strictEqual(found, wanted)
     })
   })
 })
@@ -96,7 +104,7 @@ tap.test('fetch forwards abort signal', { skip: semver.lt(process.versions.node,
 
   t.tearDown(async () => {
     await fetch.close()
-    await promisifyServerClose(server)()
+    await closeServer(server)
   })
 
   const abortController = new AbortController() // eslint-disable-line no-undef
@@ -112,7 +120,7 @@ tap.test('fetch forwards abort signal', { skip: semver.lt(process.versions.node,
   })
 })
 
-tap.test('fetch supports multiple url origins', t => {
+tap.test('fetch supports multiple URL origins', t => {
   t.plan(6)
 
   const fetch = buildFetch()
@@ -134,7 +142,7 @@ tap.test('fetch supports multiple url origins', t => {
   t.tearDown(async () => {
     await Promise.all([
       fetch.close(),
-      ...servers.map(server => promisifyServerClose(server)())
+      ...servers.map(server => closeServer(server))
     ])
   })
 
@@ -163,7 +171,7 @@ tap.test('fetch supports multiple requests to same origin', t => {
 
   t.tearDown(async () => {
     await fetch.close()
-    await promisifyServerClose(server)()
+    await closeServer(server)
   })
 
   server.listen(0, async () => {
@@ -206,7 +214,7 @@ tap.test('fetch supports many requests to many servers', t => {
   t.tearDown(async () => {
     await Promise.all([
       fetch.close(),
-      ...servers.map(server => promisifyServerClose(server)())
+      ...servers.map(server => closeServer(server))
     ])
   })
 

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -2,7 +2,7 @@
 
 const { promisify } = require('util')
 
-const promisifyServerClose = server => promisify(server.close.bind(server))
+const closeServer = server => promisify(server.close).call(server)
 
 // Header validation testing utils
 const validHeaderNameRanges = [
@@ -43,7 +43,7 @@ const allValidHeaderNameCharacters = generateCharacters(validHeaderNameRanges)
 const allValidHeaderValueCharacters = generateCharacters(validHeaderValueRanges)
 
 module.exports = {
-  promisifyServerClose,
+  closeServer,
   allValidHeaderNameCharacters,
   allValidHeaderValueCharacters
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,6 +2,8 @@
 
 const tap = require('tap')
 const stream = require('stream')
+const Request = require('../src/request')
+const Headers = require('../src/headers')
 const {
   isReadable,
   validateHeaderName,
@@ -10,7 +12,8 @@ const {
   normalizeAndValidateHeaderValue,
   normalizeAndValidateHeaderArguments,
   HeaderNameValidationError,
-  HeaderValueValidationError
+  HeaderValueValidationError,
+  createUndiciRequestOptions
 } = require('../src/utils')
 const {
   allValidHeaderNameCharacters,
@@ -98,4 +101,29 @@ tap.test('normalizeAndValidate utils', t => {
 
   const normalizedNameAndValue = normalizeAndValidateHeaderArguments(nonNormalizedName, nonNormalizedValue)
   t.strictDeepEqual(normalizedNameAndValue, ['undici', 'fetch'])
+})
+
+tap.test('createUndiciRequestOptions', t => {
+  t.plan(1)
+
+  t.test('handles GET request with query string', t => {
+    t.plan(1)
+
+    const origin = 'https://example.com'
+    const path = '/My%20Folder/index.html?foo=bar&Hello%20World=Hi%20There%3F'
+    const url = origin + path
+    const request = new Request(url)
+    const signal = undefined
+
+    const found = createUndiciRequestOptions(request, signal)
+    const wanted = {
+      method: 'GET',
+      path,
+      headers: new Headers(),
+      body: null,
+      signal
+    }
+
+    t.strictDeepEqual(found, wanted)
+  })
 })


### PR DESCRIPTION
Improves on #26:

- Appends `URL#search` so we don't lose the query string.
- Extracts the creation of undici options to a testable unit and adds a test for it.
- Checks `Pool#closed` before calling `close`. Without this, I was getting _ClientDestroyedError: The client is destroyed_, so something like a double free. 
- Moves the last assertion of the simple POST test until after the response has been received. By adding some logging, I noticed that the teardown logic was being called before the response had gone through, which seemed shady.
- Replaces `promisifyServerClose` with a simpler `closeServer` helper.