### PR TITLE
Convert undici RequestAbortedError to AbortError

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,13 @@ function isReadable (obj) {
   return obj instanceof stream.Stream && typeof obj._read === 'function' && typeof obj._readableState === 'object'
 }
 
+class AbortError extends Error {
+  constructor () {
+    super('The operation was aborted')
+    this.name = 'AbortError'
+  }
+}
+
 function HeaderNameValidationError (name) {
   return TypeError(`Invalid Header name: ${name}`)
 }
@@ -71,6 +78,7 @@ function normalizeAndValidateHeaderArguments (name, value) {
 
 module.exports = {
   isReadable,
+  AbortError,
   HeaderNameValidationError,
   HeaderValueValidationError,
   validateHeaderName,

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -4,7 +4,7 @@ const tap = require('tap')
 const semver = require('semver')
 const http = require('http')
 const { Readable } = require('stream')
-const { errors } = require('undici')
+const { AbortError } = require('../src/utils')
 const { promisifyServerClose } = require('./testUtils')
 
 const validURL = 'https://undici-fetch.dev'
@@ -107,7 +107,7 @@ tap.test('fetch forwards abort signal', { skip: semver.lt(process.versions.node,
     try {
       await fetch(`http://localhost:${server.address().port}`, { signal: abortController.signal })
     } catch (err) {
-      t.ok(err instanceof errors.RequestAbortedError)
+      t.ok(err instanceof AbortError)
     }
   })
 })


### PR DESCRIPTION
The [Fetch spec](https://fetch.spec.whatwg.org/) mandates that an abort signal be turned into an `AbortError`.