### PR TITLE
chore: update benchmarking to include libs using a shared agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,30 +68,35 @@ Built on [Undici](https://github.com/nodejs/undici)
 
 `npm run benchmarks`
 
-On my personal machine:
+On a personal machine:
 
 ```
-MacBook Pro (15-inch, 2018)
-Processor 2.9 GHz 6-Core Intel Core i9
-Memory 32 GB 2400 MHz DDR4
+MacBook Pro (16-inch, 2019)
+Processor 2.4 GHz 8-Core Intel Core i9
+Memory 32 GB 2667 MHz DDR4
 ```
 
 Results:
 
 ```
-{
-  undici: { startTime: 72530288319510n, endTime: 72544207363031n },
-  node: { startTime: 72530283341532n, endTime: 72575809241450n },
-  minipass: { startTime: 72530290384674n, endTime: 72576867597178n }
-}
-Results for 10000 subsequent requests: 
-undici-fetch | total time: 13919043521ns (13919.044ms)
-node-fetch | total time: 45525899918ns (45525.900ms)
-minipass-fetch | total time: 46577212504ns (46577.213ms)
+Results for 10000 subsequent requests:
+undici-fetch              | total time: 13545309464ns (13545.309ms)
+node-fetch                | total time: 40094125331ns (40094.125ms)
+node-fetch_with-agent     | total time: 15011468546ns (15011.469ms)
+minipass-fetch            | total time: 40081950980ns (40081.951ms)
+minipass-fetch_with-agent | total time: 15551247404ns (15551.247ms)
+axios                     | total time: 40082953438ns (40082.953ms)
+axios_with-agent          | total time: 15784146768ns (15784.147ms)
 ---
-undici-fetch <> node-fetch percent change: -69.426%
-undici-fetch <> minipass-fetch percent change: -70.116%
+undici-fetch <> node-fetch percent change: -66.216%
+undici-fetch <> node-fetch_with-agent percent change: -9.767%
+undici-fetch <> minipass-fetch percent change: -66.206%
+undici-fetch <> minipass-fetch_with-agent percent change: -12.899%
+undici-fetch <> axios percent change: -66.207%
+undici-fetch <> axios_with-agent percent change: -14.184%
 ```
+
+The `with-agent` variants use a `new http.Agent({ keepAlive: true })` to share a network connection similarly to what Undici does to make the comparison more fair.
 
 # API
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -12,9 +12,9 @@ function printResults (results, n) {
   })
   console.log('---')
   Object.entries(results).forEach(([key, timing]) => {
-    if(key === 'undici-fetch') return
+    if (key === 'undici-fetch') return
     const elapsedTT = Number.parseFloat(timing.endTime - timing.startTime)
-    const percent =((baselineTiming - elapsedTT) / elapsedTT) * 100
+    const percent = ((baselineTiming - elapsedTT) / elapsedTT) * 100
     console.log(`undici-fetch <> ${key} percent change: ${percent.toFixed(3)}%`)
   })
 }
@@ -50,7 +50,7 @@ if (isMainThread) {
       spawnWorker(N, url, 'minipass-fetch'),
       spawnWorker(N, url, 'minipass-fetch_with-agent'),
       spawnWorker(N, url, 'axios'),
-      spawnWorker(N, url, 'axios_with-agent'),
+      spawnWorker(N, url, 'axios_with-agent')
     ]).then(values => {
       const results = {}
       for (const { clientType, startTime, endTime } of values) {
@@ -71,50 +71,58 @@ if (isMainThread) {
   let fetchClient = null
   let close = false
   switch (clientType) {
-    case 'undici-fetch':
+    case 'undici-fetch': {
       fetchClient = require('../src/fetch')()
       close = true
       break
-    case 'node-fetch':
+    }
+    case 'node-fetch': {
       fetchClient = require('node-fetch')
       break
-    case 'node-fetch_with-agent':
+    }
+    case 'node-fetch_with-agent': {
       const fetch = require('node-fetch')
       const fetchHttpAgent = new http.Agent({ keepAlive: true })
       const fetchHttpsAgent = new https.Agent({ keepAlive: true })
-      const fetchAgent = (_parsedURL) => _parsedURL.protocol == 'http:' ? fetchHttpAgent : fetchHttpsAgent;
+      const fetchAgent = (_parsedURL) => _parsedURL.protocol === 'http:' ? fetchHttpAgent : fetchHttpsAgent
       fetchClient = (url) => {
         return fetch(url, {
           agent: fetchAgent
         })
       }
       break
-    case 'minipass-fetch':
+    }
+    case 'minipass-fetch': {
       fetchClient = require('minipass-fetch')
       break
-    case 'minipass-fetch_with-agent':
+    }
+    case 'minipass-fetch_with-agent': {
       const minipassFetch = require('minipass-fetch')
       const mpHttpAgent = new http.Agent({ keepAlive: true })
       const mpHttpsAgent = new https.Agent({ keepAlive: true })
-      const mpAgent = (_parsedURL) => _parsedURL.protocol == 'http:' ? mpHttpAgent : mpHttpsAgent;
+      const mpAgent = (_parsedURL) => _parsedURL.protocol === 'http:' ? mpHttpAgent : mpHttpsAgent
       fetchClient = (url) => {
         return minipassFetch(url, {
           agent: mpAgent
         })
       }
       break
-    case 'axios':
+    }
+    case 'axios': {
       fetchClient = require('axios')
       break
-    case 'axios_with-agent':
+    }
+    case 'axios_with-agent': {
       const axios = require('axios')
       fetchClient = axios.create({
         httpAgent: new http.Agent({ keepAlive: true }),
-        httpsAgent: new https.Agent({ keepAlive: true }),
+        httpsAgent: new https.Agent({ keepAlive: true })
       })
       break
-    default:
+    }
+    default: {
       throw Error(`Invalid fetch client ${clientType}`)
+    }
   }
 
   const run = async (N, url, fetchClient) => {

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -5,17 +5,18 @@ const { Worker, isMainThread, parentPort, workerData } = require('worker_threads
 
 function printResults (results, n) {
   console.log(`Results for ${n} subsequent requests: `)
-  const undiciFetchTT = Number.parseInt(results.undici.endTime - results.undici.startTime)
-  const nodeFetchTT = Number.parseInt(results.node.endTime - results.node.startTime)
-  const minipassFetchTT = Number.parseInt(results.minipass.endTime - results.minipass.startTime)
-  console.log(`undici-fetch | total time: ${undiciFetchTT}ns (${(undiciFetchTT * 0.000001).toFixed(3)}ms)`)
-  console.log(`node-fetch | total time: ${nodeFetchTT}ns (${(nodeFetchTT * 0.000001).toFixed(3)}ms)`)
-  console.log(`minipass-fetch | total time: ${minipassFetchTT}ns (${(minipassFetchTT * 0.000001).toFixed(3)}ms)`)
+  const baselineTiming = Number.parseInt(results['undici-fetch'].endTime - results['undici-fetch'].startTime)
+  Object.entries(results).forEach(([key, timing]) => {
+    const elapsedTT = Number.parseFloat(timing.endTime - timing.startTime)
+    console.log(`${key.padEnd(25)} | total time: ${elapsedTT}ns (${(elapsedTT * 0.000001).toFixed(3)}ms)`)
+  })
   console.log('---')
-  const pc1 = ((undiciFetchTT - nodeFetchTT) / nodeFetchTT) * 100
-  console.log(`undici-fetch <> node-fetch percent change: ${pc1.toFixed(3)}%`)
-  const pc2 = ((undiciFetchTT - minipassFetchTT) / minipassFetchTT) * 100
-  console.log(`undici-fetch <> minipass-fetch percent change: ${pc2.toFixed(3)}%`)
+  Object.entries(results).forEach(([key, timing]) => {
+    if(key === 'undici-fetch') return
+    const elapsedTT = Number.parseFloat(timing.endTime - timing.startTime)
+    const percent =((baselineTiming - elapsedTT) / elapsedTT) * 100
+    console.log(`undici-fetch <> ${key} percent change: ${percent.toFixed(3)}%`)
+  })
 }
 
 if (isMainThread) {
@@ -43,9 +44,13 @@ if (isMainThread) {
     })
 
     Promise.all([
-      spawnWorker(N, url, 'undici'),
-      spawnWorker(N, url, 'node'),
-      spawnWorker(N, url, 'minipass')
+      spawnWorker(N, url, 'undici-fetch'),
+      spawnWorker(N, url, 'node-fetch'),
+      spawnWorker(N, url, 'node-fetch_with-agent'),
+      spawnWorker(N, url, 'minipass-fetch'),
+      spawnWorker(N, url, 'minipass-fetch_with-agent'),
+      spawnWorker(N, url, 'axios'),
+      spawnWorker(N, url, 'axios_with-agent'),
     ]).then(values => {
       const results = {}
       for (const { clientType, startTime, endTime } of values) {
@@ -60,18 +65,53 @@ if (isMainThread) {
 } else {
   const { N, url, clientType } = workerData
 
+  const http = require('http')
+  const https = require('https')
+
   let fetchClient = null
   let close = false
   switch (clientType) {
-    case 'undici':
+    case 'undici-fetch':
       fetchClient = require('../src/fetch')()
       close = true
       break
-    case 'node':
+    case 'node-fetch':
       fetchClient = require('node-fetch')
       break
-    case 'minipass':
+    case 'node-fetch_with-agent':
+      const fetch = require('node-fetch')
+      const fetchHttpAgent = new http.Agent({ keepAlive: true })
+      const fetchHttpsAgent = new https.Agent({ keepAlive: true })
+      const fetchAgent = (_parsedURL) => _parsedURL.protocol == 'http:' ? fetchHttpAgent : fetchHttpsAgent;
+      fetchClient = (url) => {
+        return fetch(url, {
+          agent: fetchAgent
+        })
+      }
+      break
+    case 'minipass-fetch':
       fetchClient = require('minipass-fetch')
+      break
+    case 'minipass-fetch_with-agent':
+      const minipassFetch = require('minipass-fetch')
+      const mpHttpAgent = new http.Agent({ keepAlive: true })
+      const mpHttpsAgent = new https.Agent({ keepAlive: true })
+      const mpAgent = (_parsedURL) => _parsedURL.protocol == 'http:' ? mpHttpAgent : mpHttpsAgent;
+      fetchClient = (url) => {
+        return minipassFetch(url, {
+          agent: mpAgent
+        })
+      }
+      break
+    case 'axios':
+      fetchClient = require('axios')
+      break
+    case 'axios_with-agent':
+      const axios = require('axios')
+      fetchClient = axios.create({
+        httpAgent: new http.Agent({ keepAlive: true }),
+        httpsAgent: new https.Agent({ keepAlive: true }),
+      })
       break
     default:
       throw Error(`Invalid fetch client ${clientType}`)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.37",
+    "axios": "^0.21.1",
     "minipass-fetch": "^1.3.2",
     "node-fetch": "^2.6.1",
     "semver": "^7.3.4",


### PR DESCRIPTION
1) adds entries for other libraries when using a keepalive agent. This makes the comparisons more apples-to-apples. 
2) adds axios to the benchmark table