### PR TITLE
[WIP] add fetch node-fetch test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ dist
 .tern-port
 
 # node-fetch tests
-test/node-fetch/test
+test/node-fetch/files

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# node-fetch tests
+test/node-fetch/test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:js": "standard --verbose",
     "lint:ts": "ts-standard --verbose",
     "lint": "npm run lint:js && npm run lint:ts",
-    "test": "tap -J --test-ignore='testUtils.js|node-fetch/*'",
+    "test": "tap",
     "test:node-fetch": "node test/node-fetch",
     "bench": "node benchmarks"
   },
@@ -40,5 +40,9 @@
     "tap": "^15.0.6",
     "ts-standard": "^10.0.0",
     "typescript": "^4.2.4"
+  },
+  "tap": {
+    "jobs": 16,
+    "test-ignore": "testUtils.js|node-fetch/*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint:js": "standard --verbose",
     "lint:ts": "ts-standard --verbose",
     "lint": "npm run lint:js && npm run lint:ts",
-    "test": "tap -J --test-ignore='testUtils.js'",
+    "test": "tap -J --test-ignore='testUtils.js|node-fetch/*'",
+    "test:node-fetch": "node test/node-fetch",
     "bench": "node benchmarks"
   },
   "repository": {
@@ -25,7 +26,7 @@
   },
   "homepage": "https://github.com/Ethan-Arrowood/undici-fetch#readme",
   "dependencies": {
-    "undici": "^4.0.0-rc.1"
+    "undici": "^4.0.0-rc.3"
   },
   "devDependencies": {
     "@types/node": "^14.14.37",
@@ -33,6 +34,7 @@
     "axios": "^0.21.1",
     "minipass-fetch": "^1.3.2",
     "node-fetch": "^2.6.1",
+    "octokit": "^1.0.4",
     "semver": "^7.3.5",
     "standard": "^16.0.3",
     "tap": "^15.0.6",

--- a/test/node-fetch/index.js
+++ b/test/node-fetch/index.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const { Octokit } = require('octokit')
+const { promises: fs } = require('fs')
+const { join } = require('path')
+const octokit = new Octokit({ userAgent: 'undici-fetch' })
+
+async function getNodeFetchTests () {
+  const { data: content } = await octokit.rest.repos.getContent({
+    owner: 'node-fetch',
+    repo: 'node-fetch'
+  })
+
+  let { sha } = content.find(item => item.name === 'test')
+  let downloadNodeFetchTests = true
+  if ((await fs.stat(join(__dirname, 'test'))).isDirectory() &&
+      (await fs.stat(join(__dirname, '.cache'))).isFile()) {
+    const cached = await fs.readFile(join(__dirname, '.cache'), { encoding: 'utf-8' })
+    if (cached.length > 0) {
+      const cachedSha = cached.split('=')[1]
+      if (cachedSha === sha) {
+        downloadNodeFetchTests = false
+      } else {
+        sha = cachedSha
+      }
+    }
+  }
+  await fs.writeFile(join(__dirname, '.cache'), `node-fetch-sha=${sha}`, { encoding: 'utf-8' })
+
+  if (downloadNodeFetchTests) {
+    const { data } = await octokit.rest.git.getTree({
+      owner: 'node-fetch',
+      repo: 'node-fetch',
+      tree_sha: sha,
+      recursive: true
+    })
+    await fs.rm(join(__dirname, 'test'), { recursive: true, force: true })
+    await fs.mkdir(join(__dirname, 'test'), {})
+    for (const entry of data.tree) {
+      if (entry.type === 'blob') {
+        const { data: { content, encoding } } = await octokit.rest.git.getBlob({
+          owner: 'node-fetch',
+          repo: 'node-fetch',
+          file_sha: entry.sha
+        })
+        console.log(data)
+        await fs.writeFile(join(__dirname, 'test', entry.path), Buffer.from(content, encoding).toString('utf-8'))
+      } else if (entry.type === 'tree') {
+        await fs.mkdir(join(__dirname, 'test', entry.path))
+      } else {
+        throw new Error(`Unrecognized file type ${entry.type}`)
+      }
+    }
+  }
+}
+
+getNodeFetchTests()

--- a/test/node-fetch/index.js
+++ b/test/node-fetch/index.js
@@ -1,16 +1,24 @@
 'use strict'
 
 const { Octokit } = require('octokit')
-const { promises: fs } = require('fs')
-const { join } = require('path')
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert/strict')
 
-async function intializeOctokit () {
+const paths = {
+  base: path.join(__dirname, 'files'),
+  cache: path.join(__dirname, '.cache')
+}
+
+const wantedContent = new Set([ 'test', 'package.json' ])
+
+function intializeOctokit () {
   const warningMessage = 'Warning: gh_pat not found in .env file. You may encounter an API rate limit error for the GitHub API. To fix this, generate a PAT token (https://github.com/settings/tokens), create a .env file in the root of the undici-fetch directory, and assign the token to `gh_pat`.\nFor example: echo \'gh_pat=<paste_PAT_token_here>\' >> .env'
 
   let ghPAT = null
 
   try {
-    const data = await fs.readFile('.env', { encoding: 'utf-8' })
+    const data = fs.readFileSync('.env', { encoding: 'utf-8' })
     if (data.length === 0 || !data.includes('gh_pat')) {
       console.warn(warningMessage)
     } else {
@@ -27,10 +35,18 @@ async function intializeOctokit () {
   return new Octokit({ userAgent: 'undici-fetch', auth: ghPAT })
 }
 
-async function fileOrDirectoryExists (path) {
+const octokit = intializeOctokit()
+
+/**
+ * Checks for the existance of local **test** directory and **.cache** file. Re-throws errors that are not `error.code === ENOENT`
+ * @returns {boolean} true if both items exist
+ */
+function cacheFileAndBaseDirExist () {
   try {
-    const stat = await fs.stat(path)
-    return stat.isDirectory() || stat.isFile()
+    const baseStat = fs.statSync(paths.base)
+    const baseDirFiles = fs.readdirSync(paths.base)
+    const cacheStat = fs.statSync(paths.cache)
+    return baseStat.isDirectory() && baseDirFiles.length > 0 && cacheStat.isFile()
   } catch (error) {
     if (error.code === 'ENOENT') {
       return false
@@ -39,54 +55,115 @@ async function fileOrDirectoryExists (path) {
   }
 }
 
-async function getNodeFetchTests () {
-  const octokit = await intializeOctokit()
+/**
+ * Verifies if the content is currently cached or not. Re-throws non-AssertionErrors.
+ * @param {Array} content 
+ * @returns {boolean} true if deep strict equal to cached content
+ */
+function verifyCache (content) {
+  if (cacheFileAndBaseDirExist()) {
+    const cache = JSON.parse(fs.readFileSync(paths.cache, { encoding: 'utf-8' }))
 
-  const { data: content } = await octokit.rest.repos.getContent({
+    try {
+      assert.deepStrictEqual(content, cache)
+      return true
+    } catch (error) {
+      if (error instanceof assert.AssertionError) {
+        return false
+      } else {
+        throw error
+      }
+    }
+  } else {
+    return false
+  }
+}
+
+async function downloadTree (treePath, treeSha) {
+  const { data } = await octokit.rest.git.getTree({
+    owner: 'node-fetch',
+    repo: 'node-fetch',
+    tree_sha: treeSha,
+    recursive: true
+  })
+
+  fs.rmSync(treePath, { recursive: true, force: true })
+  fs.mkdirSync(treePath)
+
+  const createDirectories = data.tree.reduce((accumulator, entry) => {
+    if (entry.type === 'tree') {
+      accumulator.push(fs.promises.mkdir(path.join(treePath, entry.path)))
+    }
+
+    return accumulator
+  }, [])
+
+  await Promise.all(createDirectories)
+
+  const createBlobs = data.tree.reduce((accumulator, entry) => {
+    if (entry.type === 'blob') {
+      accumulator.push(downloadFile(path.join(treePath, entry.path), entry.sha))
+    } 
+
+    return accumulator
+  }, [])
+
+  await Promise.all(createBlobs)
+}
+
+async function downloadFile (filePath, fileSha) {
+  const { data: blob } = await octokit.rest.git.getBlob({
+    owner: 'node-fetch',
+    repo: 'node-fetch',
+    file_sha: fileSha
+  })
+
+  return fs.promises.writeFile(filePath, blob.content, {
+    encoding: blob.encoding
+  })
+}
+
+/**
+ * 
+ * @param {Array} content 
+ */
+async function downloadContent(content) {
+  const downloads = content.reduce((accumulator, entry) => {
+    if (entry.type === 'dir') {
+      accumulator.push(downloadTree(path.join(paths.base, entry.path), entry.sha))
+    } else if (entry.type === 'file') {
+      accumulator.push(downloadFile(path.join(paths.base, entry.path), entry.sha))
+    } else {
+      throw new Error(`Unrecognized entry type ${entry.type}`)
+    }
+
+    return accumulator
+  }, [])
+  await Promise.all(downloads)
+}
+
+async function getNodeFetchTestFiles () {
+  const { data: repoContent } = await octokit.rest.repos.getContent({
     owner: 'node-fetch',
     repo: 'node-fetch'
   })
 
-  let { sha } = content.find(item => item.name === 'test')
-  let downloadNodeFetchTests = true
-  if (await fileOrDirectoryExists(join(__dirname, 'test')) &&
-      await fileOrDirectoryExists(join(__dirname, '.cache'))) {
-    const cached = await fs.readFile(join(__dirname, '.cache'), { encoding: 'utf-8' })
-    if (cached.length > 0) {
-      const cachedSha = cached.split('=')[1]
-      if (cachedSha === sha) {
-        downloadNodeFetchTests = false
-      } else {
-        sha = cachedSha
-      }
-    }
-  }
-  await fs.writeFile(join(__dirname, '.cache'), `node-fetch-sha=${sha}`, { encoding: 'utf-8' })
+  const content = repoContent.filter(({ name }) => wantedContent.has(name))
 
-  if (downloadNodeFetchTests) {
-    const { data } = await octokit.rest.git.getTree({
-      owner: 'node-fetch',
-      repo: 'node-fetch',
-      tree_sha: sha,
-      recursive: true
-    })
-    await fs.rm(join(__dirname, 'test'), { recursive: true, force: true })
-    await fs.mkdir(join(__dirname, 'test'), {})
-    for (const entry of data.tree) {
-      if (entry.type === 'blob') {
-        const { data: { content, encoding } } = await octokit.rest.git.getBlob({
-          owner: 'node-fetch',
-          repo: 'node-fetch',
-          file_sha: entry.sha
-        })
-        await fs.writeFile(join(__dirname, 'test', entry.path), Buffer.from(content, encoding).toString('utf-8'))
-      } else if (entry.type === 'tree') {
-        await fs.mkdir(join(__dirname, 'test', entry.path))
-      } else {
-        throw new Error(`Unrecognized file type ${entry.type}`)
-      }
-    }
+  if (!verifyCache(content)) {
+    fs.mkdirSync(paths.base)
+    fs.writeFileSync(paths.cache, JSON.stringify(content), { encoding: 'utf-8' })
+
+    await downloadContent(content)
   }
 }
 
-getNodeFetchTests()
+async function patchPackageJSON (sha) {
+  const { data: { content, encoding } } = await octokit.rest.git.getBlob({
+    owner: 'node-fetch',
+    repo: 'node-fetch',
+    file_sha: sha
+  })
+}
+
+getNodeFetchTestFiles()

--- a/test/node-fetch/index.js
+++ b/test/node-fetch/index.js
@@ -3,9 +3,45 @@
 const { Octokit } = require('octokit')
 const { promises: fs } = require('fs')
 const { join } = require('path')
-const octokit = new Octokit({ userAgent: 'undici-fetch' })
+
+async function intializeOctokit () {
+  const warningMessage = 'Warning: gh_pat not found in .env file. You may encounter an API rate limit error for the GitHub API. To fix this, generate a PAT token (https://github.com/settings/tokens), create a .env file in the root of the undici-fetch directory, and assign the token to `gh_pat`.\nFor example: echo \'gh_pat=<paste_PAT_token_here>\' >> .env'
+
+  let ghPAT = null
+
+  try {
+    const data = await fs.readFile('.env', { encoding: 'utf-8' })
+    if (data.length === 0 || !data.includes('gh_pat')) {
+      console.warn(warningMessage)
+    } else {
+      ghPAT = data.split('=')[1]
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.warn(warningMessage)
+    } else {
+      throw error
+    }
+  }
+
+  return new Octokit({ userAgent: 'undici-fetch', auth: ghPAT })
+}
+
+async function fileOrDirectoryExists (path) {
+  try {
+    const stat = await fs.stat(path)
+    return stat.isDirectory() || stat.isFile()
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+}
 
 async function getNodeFetchTests () {
+  const octokit = await intializeOctokit()
+
   const { data: content } = await octokit.rest.repos.getContent({
     owner: 'node-fetch',
     repo: 'node-fetch'
@@ -13,8 +49,8 @@ async function getNodeFetchTests () {
 
   let { sha } = content.find(item => item.name === 'test')
   let downloadNodeFetchTests = true
-  if ((await fs.stat(join(__dirname, 'test'))).isDirectory() &&
-      (await fs.stat(join(__dirname, '.cache'))).isFile()) {
+  if (await fileOrDirectoryExists(join(__dirname, 'test')) &&
+      await fileOrDirectoryExists(join(__dirname, '.cache'))) {
     const cached = await fs.readFile(join(__dirname, '.cache'), { encoding: 'utf-8' })
     if (cached.length > 0) {
       const cachedSha = cached.split('=')[1]
@@ -43,7 +79,6 @@ async function getNodeFetchTests () {
           repo: 'node-fetch',
           file_sha: entry.sha
         })
-        console.log(data)
         await fs.writeFile(join(__dirname, 'test', entry.path), Buffer.from(content, encoding).toString('utf-8'))
       } else if (entry.type === 'tree') {
         await fs.mkdir(join(__dirname, 'test', entry.path))


### PR DESCRIPTION
Closes #19 

This pr is a work-in-progress. I'll update the description here as I dev out each piece of the intended solution.

Goal: Write a script that downloads the latest node-fetch test directory, necessary dependencies, and then execute the test suite using undici-fetch. Collect and report the results.
The script should:
- [x] check for, warn if missing, and use GitHub API PAT for Octokit
- [x] cache the downloaded test directory using the node-fetch **test** directory tree sha
- [ ] be configurable to ignore certain tests if necessary
- [ ] download necessary dependencies to execute the node-fetch test suite
- [ ] collect test results for debugging purposes
Bonuses:
- [ ] works in a CI environment 

Currently, the script found at **test/node-fetch/index.js** downloads the latest node-fetch test directory. It has a built in caching system that checks a `sha` value stored in **test/node-fetch/.cache** before redownloading the node-fetch test directory. This will help reduce unnecessary downloads in subsequent runs (at least locally or another persisted environment).
