### PR TITLE
use BodyMixin function instead of class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ _named exports_:
 * [`Request`](#class-request)
 * [`Response`](#class-response)
 * [`Headers`](#class-headers)
-* [`Body`](#class-body)
 * [`setGlobalDispatcher`](https://undici.nodejs.org/#/?id=undicisetglobaldispatcherdispatcher)
 * [`getGlobalDispatcher`](https://undici.nodejs.org/#/?id=undicigetglobaldispatcher)
 
@@ -311,118 +310,9 @@ for (const entry of headers.entries()) {
 // -> 'ghi', '789, 012'
 ```
 
-## Class: Body
-
-Represents a WHATWG Fetch Spec [Body Mixin](https://fetch.spec.whatwg.org/#body-mixin)
-
-### `new Body([input])`
-
-* **input** `AsyncIterable | Iterable | null | undefined` (optional) - Defaults to `null`
-
-This class is the core for the [Request](#class-request) and [Response](#class-response) classes. Since this class is only ever going to recieve response data from Undici requests, it only supports Readable streams.
-
-```js
-new Body()
-new Body(undefined)
-new Body(null)
-new Body('undici-fetch')
-new Body([ 'a', 'b', 'c' ])
-```
-
-### Instance Properties
-
-#### `Body.body`
-
-* `ControlledAsyncIterable | null`
-
-A property representing the payload of the Body instance. `ControlledAsyncIterable` is a mock WHATWG Readable Stream. It implements the `disturbed` property so that the Fetch api can operate accordingly.
-
-#### `Body.bodyUsed`
-
-* `boolean`
-
-A property representing the consumption state of the Body instance. Do not confuse this property with the Node.js [stream](https://nodejs.org/api/stream.html#stream_three_states) state of `Body.body`. This property is used by the other instance methods for indicating to other parts of the API if the body has been consumed or not.
-
-### Instance Methods
-
-#### `Body.arrayBuffer()`
-
-Returns: `Promise<Buffer>`
-
-Returns the `Body.body` content as a Node.js [Buffer](https://nodejs.org/api/buffer.html#buffer_class_buffer) instance.
-
-```js
-const body = new Body('undici-fetch')
-
-const buf = await body.arrayBuffer()
-console.log(buf instanceof Buffer) // -> true
-console.log(buf.toString('utf8')) // -> 'undici-fetch'
-```
-
-#### `Body.blob()`
-
-Returns: `never`
-
-Currently, this implementation does not support returning content as a blob. Calling this method will throw an error. This may change in future API updates.
-
-```js
-const body = new Body('undici-fetch')
-
-try {
-	await body.blob()
-} catch (err) {
-	console.log(err.message) // -> 'Body.blob() is not supported yet by undici-fetch'
-}
-```
-
-#### `Body.formData()`
-
-Returns: `never`
-
-Currently, this implementation does not support returning content as a blob. Calling this method will throw an error. This may change in future API updates.
-
-```js
-const body = new Body('undici-fetch')
-
-try {
-	await body.formData()
-} catch (err) {
-	console.log(err.message) // -> 'Body.formData() is not supported yet by undici-fetch'
-}
-```
-
-#### `Body.json()`
-
-Returns: `Promise<any>`
-
-Returns the `Body.body` content as a JSON object.
-
-```js
-const content = JSON.stringify({ undici: 'fetch' })
-const body = new Body(content)
-
-const res = await body.json()
-
-console.log(res) // -> { undici: 'fetch' }
-```
-
-#### `Body.text()`
-
-Returns: `Promise<string>`
-
-Returns the `Body.body` content as a UTF-8 string.
-
-```js
-const body = new Body('undici-fetch')
-
-const res = await body.text()
-
-console.log(res) // -> 'undici-fetch'
-```
-
 ## Class: Request
 
-Extends: `Body`
+Implemets: `BodyMixin`
 
 Represents a WHATWG Fetch Spec [Request Class](https://fetch.spec.whatwg.org/#request-class)
 
@@ -587,6 +477,117 @@ Returns: `Response`
 
 ```js
 const redirectResponse = Response.redirect('https://example.com', 301)
+```
+
+## Function: BodyMixin
+
+Represents a WHATWG Fetch Spec [Body Mixin](https://fetch.spec.whatwg.org/#body-mixin).
+
+Use the mixin by called `BodyMixin` with the prototype of an object.
+
+```js
+class Response {
+	constructor (body) {
+		this[kBody] = body
+	}
+}
+
+BodyMixin(Response.prototype)
+
+const response = new Response('undici-fetch')
+
+response.body // -> ControlledAsyncIterable from input 'undici-fetch'
+```
+
+### Properties
+
+#### `body`
+
+* `ControlledAsyncIterable | null`
+
+A property representing the payload of the instance. `ControlledAsyncIterable` is a mock WHATWG Readable Stream. It implements the `disturbed` property so that the Fetch api can operate accordingly.
+
+#### `bodyUsed`
+
+* `boolean`
+
+A property representing the consumption state of the instance. Do not confuse this property with the Node.js [stream](https://nodejs.org/api/stream.html#stream_three_states) state. This property is used by the other instance methods for indicating to other parts of the API if the body has been consumed or not.
+
+### Methods
+
+#### `arrayBuffer()`
+
+Returns: `Promise<Buffer>`
+
+Returns the `body` content as a Node.js [Buffer](https://nodejs.org/api/buffer.html#buffer_class_buffer) instance.
+
+```js
+const response = new Response('undici-fetch')
+
+const buf = await response.arrayBuffer()
+console.log(buf instanceof Buffer) // -> true
+console.log(buf.toString('utf8')) // -> 'undici-fetch'
+```
+
+#### `blob()`
+
+Returns: `never`
+
+Currently, this implementation does not support returning content as a blob. Calling this method will throw an error. This may change in future API updates.
+
+```js
+const response = new Response('undici-fetch')
+
+try {
+	await response.blob()
+} catch (err) {
+	console.log(err.message) // -> 'Response.blob() is not supported yet by undici-fetch'
+}
+```
+
+#### `formData()`
+
+Returns: `never`
+
+Currently, this implementation does not support returning content as a blob. Calling this method will throw an error. This may change in future API updates.
+
+```js
+const response = new Response('undici-fetch')
+
+try {
+	await response.formData()
+} catch (err) {
+	console.log(err.message) // -> 'Response.formData() is not supported yet by undici-fetch'
+}
+```
+
+#### `json()`
+
+Returns: `Promise<any>`
+
+Returns the `body` content as a JSON object.
+
+```js
+const content = JSON.stringify({ undici: 'fetch' })
+const response = new Response(content)
+
+const data = await response.json()
+
+console.log(data) // -> { undici: 'fetch' }
+```
+
+#### `text()`
+
+Returns: `Promise<string>`
+
+Returns the `body` content as a UTF-8 string.
+
+```js
+const response = new Response('undici-fetch')
+
+const text = await response.text()
+
+console.log(text) // -> 'undici-fetch'
 ```
 
 ---

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare const fetch: {
 }
 
 declare class ControlledAsyncIterable<Data> implements AsyncIterable<Data> {
+  constructor (input: AsyncIterable<Data> | Iterable<Data>)
   data: AsyncIterable<Data>
   disturbed: boolean
   [Symbol.asyncIterator] (): AsyncIterator<Data>
@@ -21,17 +22,15 @@ declare class ControlledAsyncIterable<Data> implements AsyncIterable<Data> {
 
 type BodyInput<Data = unknown> = AsyncIterable<Data> | Iterable<Data> | null | undefined
 
-declare class Body<Data = unknown> {
-  constructor (input?: BodyInput<Data>);
-
+interface BodyMixin<Data = unknown> {
   readonly body: ControlledAsyncIterable<Data> | null
   readonly bodyUsed: boolean
 
-  arrayBuffer (): Promise<Buffer>;
-  blob (): never;
-  formData (): never;
-  json (): Promise<any>;
-  text (): Promise<string>;
+  arrayBuffer: () => Promise<Buffer>
+  blob: () => never
+  formData: () => never
+  json: () => Promise<any>
+  text: () => Promise<string>
 }
 
 type HeadersInit = Headers | Iterable<[string, string]> | string[] | Record<string, string> | undefined
@@ -63,7 +62,7 @@ interface RequestInit {
   signal?: AbortSignal
 }
 
-declare class Request extends Body {
+declare class Request<Data = unknown> implements BodyMixin {
   constructor (input: Request | string, init?: RequestInit);
 
   readonly url: URL
@@ -74,6 +73,15 @@ declare class Request extends Body {
   readonly keepalive: boolean
   readonly signal: AbortSignal
 
+  readonly body: ControlledAsyncIterable<Data> | null
+  readonly bodyUsed: boolean
+
+  arrayBuffer (): Promise<Buffer>;
+  blob (): never;
+  formData (): never;
+  json (): Promise<any>;
+  text (): Promise<string>;
+
   clone (): Request;
 }
 
@@ -83,7 +91,7 @@ interface ResponseInit {
   headers?: Headers | HeadersInit
 }
 
-declare class Response extends Body {
+declare class Response<Data = unknown> implements BodyMixin {
   constructor (body: BodyInput, init?: ResponseInit)
 
   readonly headers: Headers
@@ -91,6 +99,15 @@ declare class Response extends Body {
   readonly status: number
   readonly statusText: string
   readonly type: string
+
+  readonly body: ControlledAsyncIterable<Data> | null
+  readonly bodyUsed: boolean
+
+  arrayBuffer (): Promise<Buffer>;
+  blob (): never;
+  formData (): never;
+  json (): Promise<any>;
+  text (): Promise<string>;
 
   clone (): Response;
 
@@ -101,7 +118,7 @@ declare class Response extends Body {
 export default fetch
 export { setGlobalDispatcher, getGlobalDispatcher } from 'undici'
 export type {
-  Body,
+  BodyMixin,
   Headers,
   Request,
   Response

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const { fetch } = require('./src/fetch')
 fetch.Request = require('./src/request').Request
 fetch.Response = require('./src/response').Response
 fetch.Headers = require('./src/headers').Headers
-fetch.Body = require('./src/body').Body
 
 fetch.setGlobalDispatcher = setGlobalDispatcher
 fetch.getGlobalDispatcher = getGlobalDispatcher

--- a/src/body.js
+++ b/src/body.js
@@ -5,8 +5,8 @@ const { isAsyncIterable } = require('./utils')
 
 class ControlledAsyncIterable {
   constructor (input) {
-    if (input !== null && !isAsyncIterable(input)) {
-      throw Error('input argument must be `null` or implement either `[Symbol.asyncIterator]` or `[Symbol.iterator]`')
+    if (!isAsyncIterable(input)) {
+      throw Error('input argument must implement either `[Symbol.asyncIterator]` or `[Symbol.iterator]`')
     }
 
     this.data = input
@@ -41,12 +41,12 @@ function BodyMixin (requestOrResponsePrototype) {
     },
     blob: {
       value: async function () {
-        throw Error('Body.blob() is not supported yet by undici-fetch')
+        throw Error(`${this.constructor.name}.blob() is not supported yet by undici-fetch`)
       }
     },
     formData: {
       value: async function () {
-        throw Error('Body.formData() is not supported yet by undici-fetch')
+        throw Error(`${this.constructor.name}.formData() is not supported yet by undici-fetch`)
       }
     },
     json: {

--- a/src/request.js
+++ b/src/request.js
@@ -2,7 +2,7 @@
 
 const { METHODS } = require('http')
 
-const { Body, extractBody } = require('./body')
+const { ControlledAsyncIterable, BodyMixin, extractBody } = require('./body')
 const { Headers } = require('./headers')
 
 const {
@@ -19,7 +19,8 @@ const {
   shared: {
     kHeaders,
     kUrlList
-  }
+  },
+  body: { kBody }
 } = require('./symbols')
 
 function normalizeAndValidateRequestMethod (method) {
@@ -36,7 +37,7 @@ function normalizeAndValidateRequestMethod (method) {
   return normalizedMethod
 }
 
-class Request extends Body {
+class Request {
   constructor (input, init = {}) {
     if (input instanceof Request) {
       return new Request(input.url, {
@@ -53,39 +54,29 @@ class Request extends Body {
       throw TypeError('Request input must be type Request or string')
     }
 
-    const parsedURL = new URL(input)
+    this[kUrlList] = [new URL(input)]
+    this[kKeepalive] = init.keepalive || false
+    this[kRedirect] = init.redirect || 'follow'
+    this[kIntegrity] = init.integrity || ''
+    this[kSignal] = init.signal || null
 
-    const normalizedMethod = init.method !== undefined ? normalizeAndValidateRequestMethod(init.method) : 'GET'
+    this[kMethod] = init.method !== undefined ? normalizeAndValidateRequestMethod(init.method) : 'GET'
+    this[kHeaders] = new Headers(init.headers)
+    this[kBody] = init.body || null
 
-    const keepalive = init.keepalive || false
-
-    const body = init.body || null
-
-    if (body !== null) {
-      if (normalizedMethod === 'GET' || normalizedMethod === 'HEAD') {
+    if (this[kBody] !== null) {
+      if (this[kMethod] === 'GET' || this[kMethod] === 'HEAD') {
         throw TypeError('Request with GET/HEAD method cannot have body')
       }
 
-      const [extractedBody, contentType] = extractBody(body, keepalive)
+      const [extractedBody, contentType] = extractBody(this[kBody], this[kKeepalive])
 
-      super(extractedBody)
-
-      this[kHeaders] = new Headers(init.headers)
+      this[kBody] = new ControlledAsyncIterable(extractedBody)
 
       if (contentType !== null && !this[kHeaders].has('content-type')) {
         this[kHeaders].append('content-type', contentType)
       }
-    } else {
-      super(body)
-      this[kHeaders] = new Headers(init.headers)
     }
-
-    this[kUrlList] = [parsedURL]
-    this[kRedirect] = init.redirect || 'follow'
-    this[kIntegrity] = init.integrity || ''
-    this[kKeepalive] = keepalive
-    this[kMethod] = normalizedMethod
-    this[kSignal] = init.signal || null
   }
 
   get method () {
@@ -126,5 +117,7 @@ class Request extends Body {
     return request
   }
 }
+
+BodyMixin(Request.prototype)
 
 module.exports = { Request }

--- a/test/body.js
+++ b/test/body.js
@@ -25,9 +25,9 @@ tap.test('BodyMixin', t => {
 
     const body = new Body()
 
-    body[kBody] = new ControlledAsyncIterable(null)
+    body[kBody] = null
 
-    t.ok(body.body instanceof ControlledAsyncIterable)
+    t.equal(body.body, null)
     t.equal(body.bodyUsed, false)
     t.equal(typeof body.arrayBuffer, 'function')
     t.equal(typeof body.blob, 'function')

--- a/test/body.js
+++ b/test/body.js
@@ -2,283 +2,286 @@
 
 const tap = require('tap')
 const {
-  Body,
   ControlledAsyncIterable,
   extractBody,
-  consumeBody
+  consumeBody,
+  BodyMixin
 } = require('../src/body')
+const {
+  body: {
+    kBody
+  }
+} = require('../src/symbols')
 
-tap.test('Body initialization', t => {
-  t.plan(3)
+tap.test('BodyMixin', t => {
+  t.plan(6)
 
-  t.test('defaults to null', t => {
-    t.plan(2)
+  class Body {}
+
+  BodyMixin(Body.prototype)
+
+  t.test('defines expected properties', t => {
+    t.plan(7)
+
     const body = new Body()
 
-    t.equal(body.body, null)
+    body[kBody] = new ControlledAsyncIterable(null)
+
+    t.ok(body.body instanceof ControlledAsyncIterable)
     t.equal(body.bodyUsed, false)
+    t.equal(typeof body.arrayBuffer, 'function')
+    t.equal(typeof body.blob, 'function')
+    t.equal(typeof body.formData, 'function')
+    t.equal(typeof body.json, 'function')
+    t.equal(typeof body.text, 'function')
   })
 
-  t.test('allows null and either iterables or async iterables', t => {
-    t.plan(3)
+  t.test('arrayBuffer()', t => {
+    t.plan(2)
 
-    t.doesNotThrow(() => new Body({ [Symbol.iterator]: () => {} }))
-    t.doesNotThrow(() => new Body({ [Symbol.asyncIterator]: () => {} }))
-    t.doesNotThrow(() => new Body(null))
-  })
-
-  t.test('throws on non null and non iterables inputs', t => {
-    t.plan(4)
-    const err = Error('input argument must be `null` or implement either `[Symbol.asyncIterator]` or `[Symbol.iterator]`')
-    t.throws(() => new Body(100), err, 'throws on number')
-    t.throws(() => new Body(true), err, 'throws on boolean')
-    t.throws(() => new Body(() => {}), err, 'throws on function')
-    t.throws(() => new Body({}), err, 'throws on object')
-  })
-})
-
-tap.test('Body.arrayBuffer', t => {
-  t.plan(2)
-
-  t.test('returns an arrayBuffer when body is not null', async t => {
-    function * gen () {
-      yield 'undici'
-      yield '-'
-      yield 'fetch'
-    }
-
-    const body = new Body(gen())
-
-    t.equal(body.bodyUsed, false)
-
-    const res = await body.arrayBuffer()
-
-    t.equal(body.bodyUsed, true)
-    t.ok(res instanceof Buffer)
-    t.equal(res.toString('utf-8'), 'undici-fetch')
-
-    t.end()
-  })
-
-  t.test('returns empty buffer when body does not exist', async t => {
-    const body = new Body(null)
-
-    t.equal(body.bodyUsed, false)
-
-    const res = await body.arrayBuffer()
-
-    t.equal(body.bodyUsed, false)
-    t.equal(res.length, 0)
-
-    t.end()
-  })
-})
-
-tap.test('Body.text', t => {
-  t.plan(2)
-
-  t.test('returns a string', async t => {
-    function * gen () {
-      yield 'undici'
-      yield '-'
-      yield 'fetch'
-    }
-
-    const body = new Body(gen())
-
-    t.equal(body.bodyUsed, false)
-
-    const res = await body.text()
-
-    t.equal(body.bodyUsed, true)
-    t.equal(typeof res, 'string')
-    t.equal(res, 'undici-fetch')
-
-    t.end()
-  })
-
-  t.test('returns empty string when body does not exist', async t => {
-    const body = new Body(null)
-
-    t.equal(body.bodyUsed, false)
-
-    const res = await body.text()
-
-    t.equal(body.bodyUsed, false)
-    t.equal(res, '')
-    t.end()
-  })
-})
-
-tap.test('Body.json returns a json object', async t => {
-  const json = { undici: 'fetch' }
-  const body = new Body(JSON.stringify(json))
-
-  t.equal(body.bodyUsed, false)
-
-  const res = await body.json()
-
-  t.equal(body.bodyUsed, true)
-  t.equal(typeof res, 'object')
-  t.strictSame(res, json)
-
-  t.end()
-})
-
-tap.test('Body.blob throws not supported error', async t => {
-  t.plan(2)
-
-  const body = new Body()
-  t.equal(body.bodyUsed, false)
-  t.rejects(body.blob(), Error('Body.blob() is not supported yet by undici-fetch'))
-})
-
-tap.test('Body.formData throws not supported error', async t => {
-  t.plan(2)
-
-  const body = new Body()
-  t.equal(body.bodyUsed, false)
-  t.rejects(body.formData(), Error('Body.formData() is not supported yet by undici-fetch'))
-})
-
-tap.test('Body utility classes and methods', t => {
-  t.plan(3)
-
-  t.test('ContolledAsyncIterable', t => {
-    t.plan(4)
-
-    t.test('Works with iterables', async t => {
-      const iterable = ['a', 'b', 'c']
-
-      const controlled = new ControlledAsyncIterable(iterable)
-
-      t.equal(controlled.disturbed, false)
-
-      let i = 0
-      for await (const item of controlled) {
-        t.equal(controlled.disturbed, true)
-        t.equal(item, iterable[i++])
+    t.test('returns Buffer when not null', async t => {
+      function * gen () {
+        yield 'undici'
+        yield '-'
+        yield 'fetch'
       }
+      const body = new Body()
+      body[kBody] = new ControlledAsyncIterable(gen())
+      t.equal(body.bodyUsed, false)
+
+      const res = await body.arrayBuffer()
+
+      t.equal(body.bodyUsed, true)
+      t.ok(res instanceof Buffer)
+      t.equal(res.toString('utf-8'), 'undici-fetch')
 
       t.end()
     })
 
-    t.test('Works with async iterables', async t => {
+    t.test('returns empty buffer when body does not exist', async t => {
+      const body = new Body()
+      body[kBody] = null
+
+      t.equal(body.bodyUsed, false)
+
+      const res = await body.arrayBuffer()
+
+      t.equal(body.bodyUsed, false)
+      t.equal(res.length, 0)
+
+      t.end()
+    })
+  })
+
+  t.test('text()', t => {
+    t.plan(2)
+
+    t.test('returns a string', async t => {
       function * gen () {
         yield 'undici'
         yield '-'
         yield 'fetch'
       }
 
-      const controlled = new ControlledAsyncIterable(gen())
+      const body = new Body()
+      body[kBody] = new ControlledAsyncIterable(gen())
 
-      t.equal(controlled.disturbed, false)
+      t.equal(body.bodyUsed, false)
 
-      let str = ''
-      for await (const item of controlled) {
-        t.equal(controlled.disturbed, true)
-        str += item
-      }
+      const res = await body.text()
 
-      t.equal(str, 'undici-fetch')
+      t.equal(body.bodyUsed, true)
+      t.equal(typeof res, 'string')
+      t.equal(res, 'undici-fetch')
 
       t.end()
     })
 
-    t.test('Throws error if instantiated without iterable', t => {
-      t.plan(4)
-      t.throws(() => new ControlledAsyncIterable({}))
-      t.throws(() => new ControlledAsyncIterable(() => {}))
-      t.throws(() => new ControlledAsyncIterable(0))
-      t.throws(() => new ControlledAsyncIterable(false))
-    })
+    t.test('returns empty string when body does not exist', async t => {
+      const body = new Body()
+      body[kBody] = null
 
-    t.test('Throws error if iterated when disturbed', async t => {
-      function * gen () { yield 'undici-fetch' }
+      t.equal(body.bodyUsed, false)
 
-      const controlled = new ControlledAsyncIterable(gen())
+      const res = await body.text()
 
-      t.equal(controlled.disturbed, false)
-
-      let str = ''
-      for await (const item of controlled) {
-        str += item
-      }
-
-      t.equal(str, 'undici-fetch')
-      t.equal(controlled.disturbed, true)
-
-      t.rejects(async () => {
-        for await (const _ of controlled); // eslint-disable-line no-unused-vars
-      }, 'cannot iterate on distured iterable')
-
+      t.equal(body.bodyUsed, false)
+      t.equal(res, '')
       t.end()
     })
   })
 
-  t.test('consumeBody throws if body is disturbed', async t => {
+  t.test('Body.json returns a json object', async t => {
+    const json = { undici: 'fetch' }
+    const body = new Body()
+    body[kBody] = new ControlledAsyncIterable(JSON.stringify(json))
+
+    t.equal(body.bodyUsed, false)
+
+    const res = await body.json()
+
+    t.equal(body.bodyUsed, true)
+    t.equal(typeof res, 'object')
+    t.strictSame(res, json)
+
+    t.end()
+  })
+
+  t.test('Body.blob throws not supported error', async t => {
+    t.plan(2)
+
+    const body = new Body()
+    body[kBody] = null
+
+    t.equal(body.bodyUsed, false)
+    t.rejects(body.blob(), Error('Body.blob() is not supported yet by undici-fetch'))
+  })
+
+  t.test('Body.formData throws not supported error', async t => {
+    t.plan(2)
+
+    const body = new Body()
+    body[kBody] = null
+
+    t.equal(body.bodyUsed, false)
+    t.rejects(body.formData(), Error('Body.formData() is not supported yet by undici-fetch'))
+  })
+})
+
+tap.test('ContolledAsyncIterable', t => {
+  t.plan(4)
+
+  t.test('Works with iterables', async t => {
+    const iterable = ['a', 'b', 'c']
+
+    const controlled = new ControlledAsyncIterable(iterable)
+
+    t.equal(controlled.disturbed, false)
+
+    let i = 0
+    for await (const item of controlled) {
+      t.equal(controlled.disturbed, true)
+      t.equal(item, iterable[i++])
+    }
+
+    t.end()
+  })
+
+  t.test('Works with async iterables', async t => {
+    function * gen () {
+      yield 'undici'
+      yield '-'
+      yield 'fetch'
+    }
+
+    const controlled = new ControlledAsyncIterable(gen())
+
+    t.equal(controlled.disturbed, false)
+
+    let str = ''
+    for await (const item of controlled) {
+      t.equal(controlled.disturbed, true)
+      str += item
+    }
+
+    t.equal(str, 'undici-fetch')
+
+    t.end()
+  })
+
+  t.test('Throws error if instantiated without iterable', t => {
+    t.plan(4)
+    t.throws(() => new ControlledAsyncIterable({}))
+    t.throws(() => new ControlledAsyncIterable(() => {}))
+    t.throws(() => new ControlledAsyncIterable(0))
+    t.throws(() => new ControlledAsyncIterable(false))
+  })
+
+  t.test('Throws error if iterated when disturbed', async t => {
     function * gen () { yield 'undici-fetch' }
 
     const controlled = new ControlledAsyncIterable(gen())
 
-    for await (const _ of controlled); // eslint-disable-line no-unused-vars
+    t.equal(controlled.disturbed, false)
 
-    t.rejects(() => consumeBody(controlled))
+    let str = ''
+    for await (const item of controlled) {
+      str += item
+    }
+
+    t.equal(str, 'undici-fetch')
+    t.equal(controlled.disturbed, true)
+
+    t.rejects(async () => {
+      for await (const _ of controlled); // eslint-disable-line no-unused-vars
+    }, 'cannot iterate on distured iterable')
+
     t.end()
   })
+})
 
-  t.test('extractBody', t => {
-    t.plan(8)
+tap.test('consumeBody throws if body is disturbed', async t => {
+  function * gen () { yield 'undici-fetch' }
 
-    t.strictSame(
-      extractBody(new URLSearchParams('undici=fetch&fetch=undici')),
-      [
-        Buffer.from('undici=fetch&fetch=undici'),
-        'application/x-www-form-urlencoded;charset=UTF-8'
-      ],
-      'extracts from URLSearchParams'
-    )
+  const controlled = new ControlledAsyncIterable(gen())
 
-    t.strictSame(
-      extractBody('undici-fetch'),
-      [Buffer.from('undici-fetch'), 'text/plain;charset=UTF-8'],
-      'extracts from string'
-    )
+  for await (const _ of controlled); // eslint-disable-line no-unused-vars
 
-    function * gen () { yield 'undici-fetch' }
+  t.rejects(() => consumeBody(controlled))
+  t.end()
+})
 
-    t.strictSame(
-      extractBody(gen()),
-      [gen(), null],
-      'extracts from async iterable'
-    )
+tap.test('extractBody', t => {
+  t.plan(8)
 
-    t.throws(
-      () => extractBody(gen(), true),
-      'Cannot extract body while keepalive is true'
-    )
+  t.strictSame(
+    extractBody(new URLSearchParams('undici=fetch&fetch=undici')),
+    [
+      Buffer.from('undici=fetch&fetch=undici'),
+      'application/x-www-form-urlencoded;charset=UTF-8'
+    ],
+    'extracts from URLSearchParams'
+  )
 
-    t.strictSame(
-      extractBody(['undici-fetch']),
-      [['undici-fetch'], null],
-      'extracts from iterable'
-    )
+  t.strictSame(
+    extractBody('undici-fetch'),
+    [Buffer.from('undici-fetch'), 'text/plain;charset=UTF-8'],
+    'extracts from string'
+  )
 
-    t.strictSame(
-      extractBody(new ArrayBuffer(0)),
-      [Buffer.alloc(0), null],
-      'extracts from ArrayBuffer'
-    )
+  function * gen () { yield 'undici-fetch' }
 
-    t.strictSame(
-      extractBody(new Uint8Array(0)),
-      [Buffer.alloc(0), null],
-      'extracts from ArrayBufferView'
-    )
+  t.strictSame(
+    extractBody(gen()),
+    [gen(), null],
+    'extracts from async iterable'
+  )
 
-    t.throws(
-      () => extractBody({}),
-      'Cannot extract Body from input: [object: Object]'
-    )
-  })
+  t.throws(
+    () => extractBody(gen(), true),
+    'Cannot extract body while keepalive is true'
+  )
+
+  t.strictSame(
+    extractBody(['undici-fetch']),
+    [['undici-fetch'], null],
+    'extracts from iterable'
+  )
+
+  t.strictSame(
+    extractBody(new ArrayBuffer(0)),
+    [Buffer.alloc(0), null],
+    'extracts from ArrayBuffer'
+  )
+
+  t.strictSame(
+    extractBody(new Uint8Array(0)),
+    [Buffer.alloc(0), null],
+    'extracts from ArrayBufferView'
+  )
+
+  t.throws(
+    () => extractBody({}),
+    'Cannot extract Body from input: [object: Object]'
+  )
 })

--- a/test/exports.js
+++ b/test/exports.js
@@ -20,12 +20,11 @@ tap.test('fetch forwards undici globalDispatcher methods', t => {
 })
 
 tap.test('fetch exports core classes', t => {
-  t.plan(4)
+  t.plan(3)
 
-  const { Request, Response, Headers, Body } = require('../')
+  const { Request, Response, Headers } = require('../')
 
   t.same(Request, require('../src/request').Request)
   t.same(Response, require('../src/response').Response)
   t.same(Headers, require('../src/headers').Headers)
-  t.same(Body, require('../src/body').Body)
 })


### PR DESCRIPTION
Closes #52 

This PR removes the "Body" class and replaces it with a function called `BodyMixin`. The function uses `Object.defineProperties` to define the set of properties and methods detailed by the mixin.

