### PR TITLE
allow using a URL object in Request/fetch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import Undici from 'undici'
 
 declare const fetch: {
   (
-    resource: string | Request,
+    resource: string | Request | URL,
     init?: RequestInit
   ): Promise<Response>
   Request: Request
@@ -64,7 +64,7 @@ interface RequestInit {
 }
 
 declare class Request extends Body {
-  constructor (input: Request | string, init?: RequestInit);
+  constructor (input: Request | string | URL, init?: RequestInit);
 
   readonly url: URL
   readonly method: string

--- a/src/request.js
+++ b/src/request.js
@@ -49,8 +49,8 @@ class Request extends Body {
         signal: null, // cloning signal currently not-supported
         ...init
       })
-    } else if (typeof input !== 'string') {
-      throw TypeError('Request input must be type Request or string')
+    } else if (typeof input !== 'string' && !(input instanceof URL)) {
+      throw TypeError('Request input must be type Request, URL, or string')
     }
 
     const parsedURL = new URL(input)

--- a/test/request.js
+++ b/test/request.js
@@ -8,10 +8,11 @@ const { Headers } = require('../src/headers')
 const validURL = 'http://undici-fetch.dev'
 
 tap.test('Request initialization', t => {
-  t.plan(10)
+  t.plan(11)
 
   t.throws(() => new Request(), 'throws on missing input')
   t.doesNotThrow(() => new Request(validURL), 'not throws on valid url input')
+  t.doesNotThrow(() => new Request(new URL(validURL)), 'not throws on valid url object input')
 
   t.test('default method to GET', t => {
     t.plan(1)


### PR DESCRIPTION
Allows passing URL objects to fetch and Request:

```js
await fetch(new URL('https://google.com'));

const req = new Request(new URL('https://google.com'))
```

seems like the spec allows it (although it's very hard to read), but at minimum chrome+firefox+node-fetch all allowed it 