### PR TITLE
Fix "InvalidArgumentError: body must be a string, a Buffer or a Readable stream"

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -22,7 +22,7 @@ async function fetch (resource, init) {
     const { statusCode, headers, body } = await Undici.request(request.url, {
       method: request.method,
       headers: request.headers[kHeadersList],
-      body: request.body,
+      body: request.body.data,
       signal: request.signal
     })
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -22,7 +22,7 @@ async function fetch (resource, init) {
     const { statusCode, headers, body } = await Undici.request(request.url, {
       method: request.method,
       headers: request.headers[kHeadersList],
-      body: request.body.data,
+      body: request.body?.data,
       signal: request.signal
     })
 

--- a/test/fetch/post.js
+++ b/test/fetch/post.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const tap = require('tap')
+const http = require('http')
+const { once } = require('events')
+
+const { fetch } = require('../../src/fetch')
+
+tap.test('POST request', async t => {
+  const body = JSON.stringify({ undici: 'fetch' })
+
+  const server = http.createServer(async (req, res) => {
+    t.equal(req.method, 'POST')
+    
+    let reqBody = '';
+    for await (const chunk of req) {
+        reqBody += chunk.toString();
+    }
+    
+    t.equal(reqBody, body)
+
+    res.end()
+    res.socket.unref()
+  })
+
+  t.teardown(server.close.bind(server))
+
+  server.listen()
+
+  await once(server, 'listening')
+
+  // we just need to check if the server receives the body we pass
+  await fetch(`http://localhost:${server.address().port}/`, {
+      method: 'POST',
+      body: body
+  })
+
+  t.end()
+})

--- a/test/fetch/post.js
+++ b/test/fetch/post.js
@@ -11,12 +11,12 @@ tap.test('POST request', async t => {
 
   const server = http.createServer(async (req, res) => {
     t.equal(req.method, 'POST')
-    
-    let reqBody = '';
+
+    let reqBody = ''
     for await (const chunk of req) {
-        reqBody += chunk.toString();
+      reqBody += chunk.toString()
     }
-    
+
     t.equal(reqBody, body)
 
     res.end()
@@ -31,8 +31,8 @@ tap.test('POST request', async t => {
 
   // we just need to check if the server receives the body we pass
   await fetch(`http://localhost:${server.address().port}/`, {
-      method: 'POST',
-      body: body
+    method: 'POST',
+    body: body
   })
 
   t.end()


### PR DESCRIPTION
When passing a body into `fetch`, this module is converting it to a `ControlledAsyncIterable` and passing that to undici. Undici throws an error because it's an invalid type.

Reproduce:
```js
import fetch from 'undici-fetch';

const r = await fetch('https://httpbin.org/post', {
    method: 'POST',
    body: 'test=123'
});
```