### PR TITLE
fix: Headers, Response, Request types exported as named exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,8 @@ declare class Response<Data = unknown> implements BodyMixin {
   readonly status: number
   readonly statusText: string
   readonly type: string
+  readonly url: string
+  readonly redirected: boolean
 
   readonly body: ControlledAsyncIterable<Data> | null
   readonly bodyUsed: boolean
@@ -118,7 +120,9 @@ declare class Response<Data = unknown> implements BodyMixin {
 export default fetch
 export { setGlobalDispatcher, getGlobalDispatcher } from 'undici'
 export type {
-  BodyMixin,
+  BodyMixin
+}
+export {
   Headers,
   Request,
   Response


### PR DESCRIPTION
When the `url` and `redirected` from `Response` were accessed, Typescript compiler presented a properties does not exist error

```ts
import { Response } from 'undici-fetch'

const response = new Response('undici-fetch')

response.url // Property 'url' does not exist on type 'Response<unknown>'
response.redirected // Property 'redirected' does not exist on type 'Response<unknown>'
```

Also, `Headers`, `Response` and `Request` were exported as `types`, so Typescript compiler did not allow them to be instantiated

```ts
import { Headers, Request, Response } from 'undici-fetch'

const response = new Response('undici-fetch') // 'Response' cannot be used as a value because it was exported using 'export type'
const headers = new Headers({ foo: 'bar' }) // 'Headers' cannot be used as a value because it was exported using 'export type'
const request = new Request('http://example/com') // 'Request' cannot be used as a value because it was exported using 'export type'
```

Related issue: https://github.com/Ethan-Arrowood/undici-fetch/issues/62