### PR TITLE
fix readme body mixing reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Represents a WHATWG Fetch Spec [Response Class](https://fetch.spec.whatwg.org/#r
   * **statusText** `string` (optional) - Defaults to `''`
   * **headers** `Headers | HeadersInit` (optional)
 
-Creates a new `Response` object. This is the result resolved from a successful `fetch()` call. Remember that this class extends from [Body](#class-body) so you can use methods such as `.text()` and `.json()`.
+Creates a new `Response` object. This is the result resolved from a successful `fetch()` call. Remember that this class extends from [Body](#function-bodymixin) so you can use methods such as `.text()` and `.json()`.
 
 ```js
 const response = new Response('undici-fetch')


### PR DESCRIPTION
The reference changed on c4a25f5a556423ea3780f1bcfc92ab92a2c01a53 but does not "extends" anymore https://github.com/Ethan-Arrowood/undici-fetch/pull/54 , should I reword this instead?