### PR TITLE
chore: degrade node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git+https://github.com/Ethan-Arrowood/undici-fetch.git"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=12.18"
   },
   "keywords": [
     "nodejs"

--- a/src/body.js
+++ b/src/body.js
@@ -82,7 +82,9 @@ async function consumeBody (controlledAsyncIterable) {
 }
 
 function isUnusable (controlledAsyncIterable) {
-  return controlledAsyncIterable?.disturbed ?? false
+  if (!controlledAsyncIterable) return false
+  if (controlledAsyncIterable.disturbed !== null && controlledAsyncIterable.disturbed !== void 0) return true
+  return false
 }
 
 function extractBody (body, keepalive = false) {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -22,7 +22,7 @@ async function fetch (resource, init) {
     const { statusCode, headers, body } = await Undici.request(request.url, {
       method: request.method,
       headers: request.headers[kHeadersList],
-      body: request.body?.data,
+      body: request.body && request.body.data,
       signal: request.signal
     })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,10 @@
 'use strict'
 
 function isAsyncIterable (obj) {
-  return typeof obj?.[Symbol.asyncIterator] === 'function' || typeof obj?.[Symbol.iterator] === 'function'
+  if (Symbol.iterator in Object(obj)) {
+    return typeof obj[Symbol.asyncIterator] === 'function' || typeof obj[Symbol.iterator] === 'function'
+  }
+  return false
 }
 
 /**


### PR DESCRIPTION
Thanks for the great work and this PR is about degrading the node engines field.

Since [undici specifies its node engines](https://github.com/nodejs/undici/blob/main/package.json#L71) higher than 12.18, it is better for us to keep the same requirement. Eventhough today is 2021, we should also respect a little compatiblility.

Actually it is just easy to keep this by avoid using Nullish Coalescing and Optional Chaining.